### PR TITLE
Feature/mutagen sync

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -60,6 +60,16 @@ APPLICATION=../magento
 DEVELOPMENT=1
 
 #
+# Defines which method is to be used to sync files to the application container.
+#
+# Supported values:
+#   - none: disables integrated scripts, allowing your own method (or mount) to be set up
+#   - mutagen: highly recommended on Mac and Windows. See https://mutagen.io/. 
+#              Will also result in docker-compose-mutagen.yml being used upon compose.
+#  
+APPLICATION_FILE_SYNC=none
+
+#
 # Set the default window manager when running the environment
 # Available options are: tmux, screen and byobu
 #

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ issues - like while running docker for mac - you can set the extra environment
 variable `XDEBUG_CONFIG` with your hosts ip in it so xdebug can properly
 connect back.
 
+### APPLICATION_FILE_SYNC
+
+Defines which method is to be used to sync files to the application container.
+
+Supported values:
+  * none (default): disables integrated scripts, allowing your own method 
+   (or mount) to be set up over the `docker-compose.yml`
+  * mutagen: highly recommended on Mac and Windows. See [https://mutagen.io/](https://mutagen.io/). Will also result in docker-compose-mutagen.yml being used upon compose.
+
 ### WINDOW_MANAGER
 Set the default window manager when running the environment.
 Available options are: tmux, screen and byobu

--- a/README.md
+++ b/README.md
@@ -254,17 +254,17 @@ $ brew install coreutils
 
 On macOS you could just install docker from the docker site and run like this.
 But our experience is that the native docker install is fairly slow to use. We
-would suggest you to install [dinghy](https://github.com/codekitchen/dinghy).
+would suggest you to install [Mutagen](https://mutagen.io/).
 
-[install dinghy](https://github.com/codekitchen/dinghy#install) and install the
-VM technology you want to use. If you want native xhyve support you can
-additionally install 
-[xhyve driver for docker machine](https://github.com/zchee/docker-machine-driver-xhyve).
+Mutagen is available over [Homebrew](https://brew.sh/):
+~~~ sh
+$ brew install mutagen-io/mutagen/mutagen
+~~~
 
-If you have dinghy installed this environment will try to use it.
-
-Currently there is an annoying limitation when we are using dinghy and that is
-that the hostnames used must end with `docker`.
+After [installing mutagen](https://mutagen.io/documentation/introduction/installation),
+update the `.env` config flag `APPLICATION_FILE_SYNC` to contain value `mutagen`.
+Calling `run up` from inside the `./environment` will spin up the Mutagen session
+automatically.
 
 #### tmux on macOS
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Defines which method is to be used to sync files to the application container.
 Supported values:
   * none (default): disables integrated scripts, allowing your own method 
    (or mount) to be set up over the `docker-compose.yml`
-  * mutagen: highly recommended on Mac and Windows. See [https://mutagen.io/](https://mutagen.io/). Will also result in docker-compose-mutagen.yml being used upon compose.
+  * mutagen: highly recommended on Mac and Windows. See 
+  [https://mutagen.io/](https://mutagen.io/). Will also result in 
+  docker-compose-mutagen.yml being used upon compose.
 
 ### WINDOW_MANAGER
 Set the default window manager when running the environment.
@@ -216,6 +218,26 @@ eg. `$ run up`
 This will run an installation using redis for caches and create a default admin
 user. The admin user is `admin` and the password is `DockerWest123!`. The admin
 endpoint will be found under `/admin`.
+
+### application
+
+Entry-point for operations specific to the application (php) docker container.
+Used by the `run up` command too, to facilitate file sync instances (if enabled).
+See the `help` for more information:
+
+~~~ sh
+$ application help
+~~~
+
+### mutagen-helper
+
+Assists in starting and pausing Mutagen synchronisation to the Docker application container,
+without the need to juggle around container and Mutagen session names.
+See the `help` for more information:
+
+~~~ sh
+$ mutagen-helper help
+~~~
 
 Tricks
 ------

--- a/bin/application
+++ b/bin/application
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+from environment import Environment
+from application import Application
+
+currentpath = os.getcwd()
+composepath = os.path.abspath(os.path.dirname(sys.argv[0]) + '/../')
+
+env = Environment(composepath + '/.env')
+application = Application(env)
+
+def file_sync(args):    
+    daemon = False
+    force = False
+    action_arg = args[0]
+    
+    if action_arg == 'daemon':
+        daemon = True
+        action_arg = args[1]
+
+    for arg in args:
+        if arg == 'force':
+            force = True
+            break
+
+    arg_map = {
+        'up-down': application.up_down_file_sync,
+        'up': application.up_file_sync,
+        'down': application.down_file_sync
+    }
+
+    arg_func = arg_map.get(action_arg, None)
+
+    if arg_func is None:
+        raise SystemExit(f'Invalid argument - "{action_arg}"" does not map to a valid action.')
+
+    return arg_func(force, daemon)
+
+if len(sys.argv) < 2 or sys.argv[1] == "help":
+    print("""\
+Provides application container management.
+
+Usage:
+    application [command]
+
+Supported commands:
+    file-sync   Manage file synchronisation state of the container. 
+                Requires additional commands.
+
+Use application [command] help for more info regarding a command.
+""")
+    sys.exit()
+
+if sys.argv[1] == 'file-sync':
+    if len(sys.argv) < 3 or sys.argv[2] == "help":
+        print("""\
+Manage file synchronisation state of the container. Requires additional commands.
+
+Usage:
+    application file-sync [command]
+
+Supported commands:   
+    daemon      When prefixing a command with "daemon", the command will be daemonized. 
+                Assuring desired state of application container is awaited.
+                Usage: application file-sync daemon up-down
+
+    up          Creates and/or resumes the file sync.
+    down        Halts sync.
+    up-down     Starts and halts sync. Useful for automated halting of sync upon
+                application container shutdown, when combined with daemon command.
+
+    force       Forces desired action, ignoring application container state.
+""")
+        sys.exit()
+
+    file_sync_result = file_sync(sys.argv[2:])
+
+    # TODO: must revise, types gone wrong
+    if file_sync_result is not None:
+        print(file_sync_result.strip())

--- a/bin/application.py
+++ b/bin/application.py
@@ -1,0 +1,108 @@
+import subprocess
+import sys
+import os
+from environment import Environment
+from mutagen import Mutagen
+
+class Application:
+
+    CONTAINER_SERVICE_NAME = 'application'
+
+    def __init__(self, env: Environment):
+        self.env = env
+
+    def get_file_sync_method_name(self):
+        var_map = {
+            'mutagen': 'mutagen',
+            'none': None
+        }
+
+        method_name = var_map.get(self.env.get('APPLICATION_FILE_SYNC'), False)
+
+        if method_name is False:
+            raise SystemExit('Invalid APPLICATION_FILE_SYNC value was defined, please review .env settings.')
+
+        return method_name
+
+    def start_file_sync_daemon(self):
+        file_sync_method_name = self.get_file_sync_method_name()
+        if file_sync_method_name is None:
+            return
+
+        # TODO: tried threading, no luck with first attempts. Should get rid of "application" dependency
+        file_sync_daemon_cmd = [
+            os.path.dirname(sys.argv[0]) + '/application',
+            'file-sync', 'daemon', 'up-down'
+        ]
+        subprocess.Popen(file_sync_daemon_cmd)
+
+    def get_file_sync_method(self, method_type):
+        var_map = {
+            'up_mutagen': self.up_mutagen_sync,
+            'down_mutagen': self.down_mutagen_sync
+        }
+
+        sync_method_name = self.get_file_sync_method_name()
+        target_func = var_map.get(f'{method_type}_{sync_method_name}', None)
+
+        if target_func is None:
+            raise SystemExit(f'Could not map APPLICATION_FILE_SYNC value {sync_method_name} to an up-method, implementation is missing.')
+
+        return target_func
+
+    def up_file_sync(self, ignore_container_state = False, daemon = False):
+        up_func = self.get_file_sync_method('up')
+
+        if not ignore_container_state and not self.is_container_running():
+            if not daemon:
+                raise SystemExit(f'Could not start file sync, {self.CONTAINER_SERVICE_NAME} container is not running.')
+
+            # 1800 secs, 30 min timeout, making sure download time is covered
+            # Adding delay_after too, giving the container some time become actually available
+            self.await_container('running', 1800, 0, 5)
+
+        return up_func()
+
+    def down_file_sync(self, ignore_container_state = False, daemon = False):
+        down_func = self.get_file_sync_method('down')
+
+        if not ignore_container_state and not self.is_container_down():
+            if not daemon:
+                raise SystemExit(f'Could not stop file sync, {self.CONTAINER_SERVICE_NAME} container is still running. Use helpers or direct command to manually halt the sync.')
+
+            self.await_container('down', -1)
+
+        return down_func()
+
+    def up_down_file_sync(self, ignore_container_state = False, daemon = False):
+        self.up_file_sync(ignore_container_state, daemon)
+
+        try:
+            self.down_file_sync(ignore_container_state, daemon)
+        except KeyboardInterrupt:
+            if daemon:
+                print('Detected Ctrl+C on file-sync up-down daemon, attempting to stop file sync')
+                self.down_file_sync(ignore_container_state)
+                return None
+
+        return('Succesfully started and stopped file sync, exiting.')
+
+    def up_mutagen_sync(self):
+        mutagen = Mutagen(self.env)
+        return mutagen.session_init(mutagen.get_session_name(), self.env.get('APPLICATION'), self.get_container_name())
+
+    def down_mutagen_sync(self):
+        mutagen = Mutagen(self.env)
+        return mutagen.session_terminate(mutagen.get_session_name())
+
+    def is_container_running(self):
+        return self.env.is_container_running(self.CONTAINER_SERVICE_NAME)
+
+    def is_container_down(self):
+        return self.env.is_container_down(self.CONTAINER_SERVICE_NAME)
+
+    def get_container_name(self):
+        return self.env.get_container_name(self.CONTAINER_SERVICE_NAME)
+
+    def await_container(self, state, timeout = 10, delay_before = 0, delay_after = 0):
+        return self.env.await_container(self.CONTAINER_SERVICE_NAME, state, timeout, delay_before, delay_after)

--- a/bin/environment.py
+++ b/bin/environment.py
@@ -8,6 +8,9 @@ import contextlib
 import codecs
 import re
 import shutil
+import sys
+import subprocess
+import time
 
 
 def split_env(env):
@@ -34,11 +37,10 @@ def env_vars_from_file(filename):
                 env[k] = v
     return env
 
-
 class Environment:
 
     required_keys = [
-        'BASEHOST', 'APPLICATION', 'WINDOW_MANAGER'
+        'BASEHOST', 'APPLICATION', 'WINDOW_MANAGER', 'APPLICATION_FILE_SYNC'
     ]
 
     def __init__(self, envfile):
@@ -50,9 +52,14 @@ class Environment:
             if requiredkey not in self.environment:
                 raise ValueError("Env does not contain %s" % requiredkey)
 
+    def is_tool_available(self, toolname):
+        from shutil import which
+        return which(toolname) is not None
+
     def get_compose_filename(self):
-        dingyexec = shutil.which('dinghy')
-        if None is not dingyexec:
+        if self.is_tool_available('mutagen'):
+            return 'docker-compose-mutagen.yml'
+        if self.is_tool_available('dinghy'):
             return 'docker-compose-dinghy.yml'
         return 'docker-compose.yml'
 
@@ -61,6 +68,72 @@ class Environment:
         basehost = self.get('BASEHOST')
         projectname = regex.sub('', basehost)
         return projectname
+
+    def get_container_id(self, container):
+        # TODO: might do with some additional checks, will break quite fast
+        container_id_cmd = [
+            os.path.dirname(sys.argv[0]) + '/run',
+            'ps', '-q', container
+        ]
+
+        container_id = subprocess.check_output(container_id_cmd, universal_newlines=True)
+        containerId = container_id.strip()
+
+        return containerId
+
+    def get_container_name(self, container):
+        container_id = self.get_container_id(container)
+
+        container_name_cmd = [
+            'docker',
+            'inspect', '-f', '{{.Name}}', container_id
+        ]
+
+        container_name = subprocess.check_output(container_name_cmd, universal_newlines=True)
+        container_name = container_name.strip().strip('/')
+
+        return container_name
+    
+    def is_container_running(self, container):
+        container_id = self.get_container_id(container)
+
+        if not container_id:
+            return False
+
+        container_status_cmd = [
+            'docker',
+            'inspect', '-f', '{{.State.Running}}', container_id
+        ]
+
+        container_status = subprocess.check_output(container_status_cmd, universal_newlines=True)
+        container_status = container_status.strip()
+
+        return container_status == 'true'
+    
+    def is_container_down(self, container):
+        return not self.is_container_running(container)
+
+    def await_container(self, container, state, timeout = 10, delay_before = 0, delay_after = 0):
+        req_state_map = {
+            'running': self.is_container_running,
+            'down': self.is_container_down
+        }
+
+        state_func = req_state_map.get(state, self.is_container_running)
+
+        if delay_before > 0:
+            time.sleep(delay_before)
+
+        daemon_runtime = 0
+        while not state_func(container):
+            daemon_runtime += 5
+            if timeout > 0 and daemon_runtime > timeout:
+                raise SystemExit(f'Container await timed out after {timeout}s, still not {state}.')
+
+            time.sleep(5)
+
+        if delay_after > 0:
+            time.sleep(delay_after)
 
     def get(self, key):
         if key not in self.environment:

--- a/bin/mutagen-helper
+++ b/bin/mutagen-helper
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+from environment import Environment
+from mutagen import Mutagen
+from application import Application
+
+currentpath = os.getcwd()
+composepath = os.path.abspath(os.path.dirname(sys.argv[0]) + '/../')
+
+env = Environment(composepath + '/.env')
+mutagen = Mutagen(env)
+
+if len(sys.argv) < 2 or sys.argv[1] == "help":
+    print("""\
+Assists in starting and pausing Mutagen synchronisation to the Docker application container,
+without the need to juggle around container and Mutagen session names.
+
+Usage:
+    mutangen-helper [command]
+
+Supported commands:
+    help        This help regarding the script.
+    up          Creates or resumes already created Mutagen session.
+    pause       Pauses the Mutagen session.
+    destroy     Completely removes the Mutagen session. 
+                Note: this will NOT delete files, neither in host nor in guest container.
+    monitor     Opens up the monitor view of the generated Mutagen session.
+""")
+    sys.exit()
+
+def up():
+    return mutagen.session_init(mutagen.get_session_name(), env.get('APPLICATION'), env.get_container_name(Application.CONTAINER_SERVICE_NAME))
+
+def pause():
+    return mutagen.session_pause(mutagen.get_session_name())
+
+def destroy():
+    return mutagen.session_terminate(mutagen.get_session_name())
+
+def monitor():
+    mutagen.session_monitor(mutagen.get_session_name())
+
+def exec_arg(arg):
+    arg_map = {
+        'up': up,
+        'pause': pause,
+        'destroy': destroy,
+        'monitor': monitor
+    }
+
+    argFunc = arg_map.get(arg, lambda: 'Invalid argument')
+    return argFunc()
+        
+exec_result = exec_arg(sys.argv[1])
+print(exec_result.strip())

--- a/bin/mutagen.py
+++ b/bin/mutagen.py
@@ -1,0 +1,101 @@
+import subprocess
+import os
+from environment import Environment
+
+class Mutagen:
+
+    EXEC_NAME = 'mutagen'
+    EXEC_SYNC_PARAM = 'sync'
+
+    def __init__(self, env: Environment):
+        self.env = env
+
+    def session_exists(self, session_name):
+        self.check_availability()
+
+        cmd = [
+            self.EXEC_NAME, self.EXEC_SYNC_PARAM, 'list'
+        ]
+
+        # Using universal_newlines to assure a string is always returned, avoiding issues with the .find params later on
+        mutagen_list = subprocess.check_output(cmd, universal_newlines=True)
+        mutagen_session_list_ref = 'Name: ' + session_name
+
+        return mutagen_list.find(mutagen_session_list_ref) != -1
+
+    def session_create(self, session_name, alpha_path, beta_container_name):
+        self.check_availability()
+
+        cmd = [
+                self.EXEC_NAME, 'create', 
+                '--label=dockerwest-magento-file-sync',
+                '--name=' + session_name,
+                '--sync-mode=two-way-resolved',
+                '--default-file-mode=0644',
+                '--default-directory-mode=0755',
+                '--ignore=/.idea',
+                '--ignore=/.magento',
+                '--ignore=/.docker',
+                '--ignore=/.github',
+                '--ignore=*.sql',
+                '--ignore=*.gz',
+                '--ignore=*.zip',
+                '--ignore=*.bz2',
+                '--ignore-vcs',
+                '--symlink-mode=posix-raw',
+                alpha_path,
+                # TODO: revalidate user. Experiencing permission issues with /generated files after Magerun usage.
+                'docker://www-data@' + beta_container_name + '/phpapp'
+            ]
+
+        return subprocess.check_output(cmd, universal_newlines=True)
+
+    def session_resume(self, session_name):
+        self.check_availability()
+
+        cmd = [
+            self.EXEC_NAME, self.EXEC_SYNC_PARAM, 'resume', session_name
+        ]
+
+        return subprocess.check_output(cmd, universal_newlines=True)
+
+    def session_pause(self, session_name):
+        self.check_availability()
+
+        cmd = [
+            self.EXEC_NAME, self.EXEC_SYNC_PARAM, 'pause', session_name
+        ]
+
+        return subprocess.check_output(cmd, universal_newlines=True)
+
+    def session_monitor(self, session_name):
+        self.check_availability()
+
+        cmd = [
+            self.EXEC_NAME, self.EXEC_SYNC_PARAM, 'monitor', session_name
+        ]
+
+        os.execvp(cmd[0], cmd)
+    
+    def session_terminate(self, session_name):
+        self.check_availability()
+
+        cmd = [
+            self.EXEC_NAME, self.EXEC_SYNC_PARAM, 'terminate', session_name
+        ]
+
+        return subprocess.check_output(cmd, universal_newlines=True)
+
+    def session_init(self, session_name, alpha_path, beta_container_name):
+        if not self.session_exists(session_name):
+            self.session_create(session_name, alpha_path, beta_container_name)
+
+        return self.session_resume(session_name)
+
+    def check_availability(self):
+        if not self.env.is_tool_available(self.EXEC_NAME):
+            raise SystemExit('Mutagen tooling was called, but not available on system. Please review Mutagen installation.')
+
+
+    def get_session_name(self):
+        return 'dockerwest-sync-' + self.env.get_project_name()

--- a/bin/run
+++ b/bin/run
@@ -3,12 +3,17 @@
 import os
 import sys
 from environment import Environment
+from application import Application
 
 currentpath = os.getcwd()
 composepath = os.path.abspath(os.path.dirname(sys.argv[0]) + '/../')
 os.chdir(composepath)
 
 env = Environment(composepath + '/.env')
+
+if 'up' in sys.argv:
+    application = Application(env)
+    application.start_file_sync_daemon()
 
 cmd = [
     'docker-compose', '-f', env.get_compose_filename(),

--- a/docker-compose-mutagen.yml
+++ b/docker-compose-mutagen.yml
@@ -1,0 +1,49 @@
+version: '3'
+
+services:
+  redis:
+    image: redis:alpine
+    environment:
+      - DOMAIN_NAME=redis.${BASEHOST:-magento.docker}
+
+  mysql:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-toor}
+      - DOMAIN_NAME=mysql.${BASEHOST:-magento.docker}
+    command: --innodb-doublewrite=0
+
+  mailcatcher:
+    image: mailhog/mailhog
+    environment:
+      - VIRTUAL_HOST=mailcatcher.${BASEHOST:-magento.docker}
+
+  application:
+    image: dockerwest/php-magento${MAGENTOVERSION}:${PHPVERSION:-7.0}
+    environment:
+      - C_UID=${C_UID:-1000}
+      - C_GID=${G_UID:-1000}
+      - DEVELOPMENT=${DEVELOPMENT:-1}
+    volumes:
+      - phpapp-sync:/phpapp:nocopy
+
+  nginx:
+    image: dockerwest/nginx-magento${MAGENTOVERSION}:${NGINXVERSION:-stable}
+    environment:
+      - VIRTUAL_HOST=${BASEHOST:-magento.docker},${EXTRAHOSTS}
+    volumes:
+      - phpapp-sync:/phpapp:nocopy
+
+  elastic:
+    image: blacktop/elasticsearch:5
+    environment:
+      - DOMAIN_NAME=elastic.${BASEHOST:-magento.docker}
+
+  elastic-hq:
+    image: elastichq/elasticsearch-hq
+    environment:
+      - VIRTUAL_HOST=hq.${BASEHOST:-magento.docker}
+
+volumes:
+  phpapp-sync: {  }
+


### PR DESCRIPTION
After experiencing issues on macOS, was able to integrate Mutagen. Added as a configurable / optional feature, including a daemon automatically managing the generated Mutagen sync session.

Inspired by:
https://blog.rocketinsights.com/speeding-up-docker-development-on-the-mac/
Crucial references were:
https://medium.com/netresearch/improving-performance-for-docker-on-mac-computers-when-using-named-volumes-55580efcbf68
https://devdocs.magento.com/cloud/docker/docker-syncing-data.html

Not so fluent in Python, so keep an eye open for missed best practices ...

Remaining issues/todo's:
* Only tested on macOS (10.15.4), Python 2.7.16
* To be ported to the macOS-branch (oops)
* Improve subprocess call to the file sync daemon (`Application::start_file_sync_daemon`). Contains subprocess call to shell command, to be reviewed - having it no longer depending on the shell command.
* Experiencing issues with the `www-data` user applied on the Mutagen sync session. Running commands from the application (e.g. magerun helper) results in `/generated`-files returning permission errors.